### PR TITLE
Improve until example

### DIFF
--- a/essentials/loops/until/index.md
+++ b/essentials/loops/until/index.md
@@ -11,8 +11,8 @@ Here is a modified [program from the previous page](../while) that uses `until` 
 ```raku
 my $x = 0;
 until $x > 10 {
-    $x = prompt 'Enter a number: ';
-    say "You entered $x, which is not bigger than 10.";
+    $x = prompt 'Enter a number, which is not bigger than 10: ';
+    say "You entered $x.";
 }
 say "$x is bigger than 10.";
 ```
@@ -21,14 +21,14 @@ Run the program and check the output:
 
 ```console
 $ raku t.raku 
-Enter a number: 10
-You entered 10, which is not bigger than 10.
-Enter a number: 4
-You entered 4, which is not bigger than 10.
-Enter a number: 1
-You entered 1, which is not bigger than 10.
-Enter a number: 20
-You entered 20, which is not bigger than 10.
+Enter a number, which is not bigger than 10: 10
+You entered 10.
+Enter a number, which is not bigger than 10: 4
+You entered 4.
+Enter a number, which is not bigger than 10: 1
+You entered 1.
+Enter a number, which is not bigger than 10: 20
+You entered 20.
 20 is bigger than 10.
 ```
 


### PR DESCRIPTION
Fix the `until` example in a way similar to 54c12c47a64f536e87c901f348dc9f1e94e0128b