### PR TITLE
Boolean || instead of | to be consistent

### DIFF
--- a/essentials/conditional-checks/exercises/leap-year/solution/index.md
+++ b/essentials/conditional-checks/exercises/leap-year/solution/index.md
@@ -49,7 +49,7 @@ In the second solution, the logic is packed to a single expression. Parentheses 
 ```raku
 my $year = prompt 'Year: ';
 
-say (($year %% 400) | (($year %% 4) && ($year % 100))) ?? 'Leap year' !! 'Common year';
+say (($year %% 400) || (($year %% 4) && ($year % 100))) ?? 'Leap year' !! 'Common year';
 ```
 
 🦋 Find the program in the file [leap-year-formula.raku](https://github.com/ash/raku-course/blob/master/exercises/conditional-checks/leap-year-formula.raku).


### PR DESCRIPTION
It works with the single |. I do not fully understand why. (Perl5: bitwise operator, but in raku ? any infix ?)