### PR TITLE
[Typo] missing last output word: enough

### DIFF
--- a/essentials/loops/exercises/echo-until-enough/index.md
+++ b/essentials/loops/exercises/echo-until-enough/index.md
@@ -18,6 +18,7 @@ language
 Your word: coding
 coding
 Your word: enough
+enough
 OK, done.
 ```
 


### PR DESCRIPTION
The input word is repeated on each iteration, including the last one.

This type of mismatch between example code and output can be avoided if the example code can be made to generate the output.