### PR TITLE
[Typo] 2.718281828459045 => 2.7182818284590453

### DIFF
--- a/essentials/functions/exercises/the-value-of-e/index.md
+++ b/essentials/functions/exercises/the-value-of-e/index.md
@@ -22,7 +22,7 @@ Print the results for both cases.
 ```console
 $ raku the-value-of-e.raku
 2.7182818
-2.718281828459045
+2.7182818284590453
 ```
 
 ## Solution


### PR DESCRIPTION
Missing 3: version 6.d appears to give precision of 16 decimal points.