### PR TITLE
[Fix] Dark/Light mode (Issue 13)

### DIFF
--- a/assets/course.css
+++ b/assets/course.css
@@ -1,3 +1,18 @@
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color : #002b36;
+    color            : #fdf6e3;
+    font-weight      : lighter;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  body {
+    background-color : #fdf6e3;
+    color            : #002b36;
+  }
+}
+
 ul li {
     list-style-type: none;
 }


### PR DESCRIPTION
Uses the invertible colours of [Solarized](https://en.wikipedia.org/wiki/Solarized
) by *Ethan Schoonover*.

Should address [Issue 13, Website Dark Mode Option?](https://github.com/ash/raku-course/issues/13).

No toggle, but a straight CSS solution which relies on browser support which is wide at [+90%](https://caniuse.com/prefers-color-scheme).